### PR TITLE
Add Ubuntu 18.04 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This module is currently tested on:
 
 * Ubuntu 12.04
 * Ubuntu 14.04
+* Ubuntu 18.04
 * Centos 7.0
 * Centos 6.6
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,6 +76,14 @@
 #   Any extra parameters that should be passed to the docker daemon.
 #   Defaults to undefined
 #
+# [*insecure_registry*]
+#   An insecure docker registry that should be passed to the docker daemon.
+#   Defaults to undefined
+#
+# [*without_installation*]
+#   Tells the docker module that the user itself manages the installation of docker.
+#   Defaults to false
+#
 # [*shell_values*]
 #   Array of shell values to pass into init script config files
 #
@@ -175,6 +183,8 @@ class docker(
   $dns_search                  = $docker::params::dns_search,
   $socket_group                = $docker::params::socket_group,
   $extra_parameters            = undef,
+  $insecure_registry           = undef,
+  $without_installation        = false,
   $shell_values                = undef,
   $proxy                       = $docker::params::proxy,
   $no_proxy                    = $docker::params::no_proxy,
@@ -231,10 +241,18 @@ class docker(
     fail('You need to provide both $dm_datadev and $dm_metadatadev parameters for direct lvm.')
   }
 
-  class { 'docker::install': } ->
-  class { 'docker::config': } ~>
-  class { 'docker::service': }
-  contain 'docker::install'
+  if !$without_installation {
+    class { 'docker::install': } ->
+    class { 'docker::config': } ~>
+    class { 'docker::service': }
+  } else {
+    class { 'docker::config': } ~>
+    class { 'docker::service': }
+  }
+
+  if !$without_installation {
+    contain 'docker::install'
+  }
   contain 'docker::config'
   contain 'docker::service'
 

--- a/templates/etc/default/daemon.json.erb
+++ b/templates/etc/default/daemon.json.erb
@@ -1,0 +1,12 @@
+{
+    "storage-driver": "overlay2",
+    <% if @insecure_registry %>
+    "insecure-registries": [
+        "<%= @insecure_registry %>"
+    ],
+    <% end -%>
+    "log-opts": {
+        "max-size": "50m",
+        "max-file": "3"
+    }
+}

--- a/templates/etc/default/docker.erb
+++ b/templates/etc/default/docker.erb
@@ -41,6 +41,7 @@ DOCKER_OPTS="\
 <% if @dm_metadatadev %> --storage-opt dm.metadatadev=<%= @dm_metadatadev %><% end -%>
 <% end -%>
 <% if @extra_parameters %><% @extra_parameters_array.each do |param| %> <%= param %><% end %><% end -%>
+<% if @insecure_registry %><%= @insecure_registry %><% end -%>
 "
 <% if @shell_values %><% @shell_values_array.each do |param| %>
 <%= param %><% end %><% end %>


### PR DESCRIPTION
Add 2 new parameter to pass over an insecure registry and skip the whole docker::install class.
By that the user is given the option to manage the installation himself.
Support systemd and configure the daemon via /etc/docker/daemon.json.